### PR TITLE
[Backport] 6305 - Resolved product custom option title save issue

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Option/Validator/DefaultValidator.php
+++ b/app/code/Magento/Catalog/Model/Product/Option/Validator/DefaultValidator.php
@@ -108,7 +108,7 @@ class DefaultValidator extends \Magento\Framework\Validator\AbstractValidator
         }
 
         // checking whether title is null and also changed is_empty to is_null
-        if ($this->isNull($title)) {
+        if ($title === null) {
             return false;
         }
 
@@ -169,16 +169,5 @@ class DefaultValidator extends \Magento\Framework\Validator\AbstractValidator
     protected function isNegative($value)
     {
         return intval($value) < 0;
-    }
-
-    /**
-     * check whether title is null
-     *
-     * @param $title
-     * @return bool
-     */
-    protected function isNull($title)
-    {
-        return is_null($title);
     }
 }

--- a/app/code/Magento/Catalog/Model/Product/Option/Validator/DefaultValidator.php
+++ b/app/code/Magento/Catalog/Model/Product/Option/Validator/DefaultValidator.php
@@ -106,7 +106,9 @@ class DefaultValidator extends \Magento\Framework\Validator\AbstractValidator
         if ($storeId > \Magento\Store\Model\Store::DEFAULT_STORE_ID && $title === null) {
             return true;
         }
-        if ($this->isEmpty($title)) {
+
+        // checking whether title is null and also changed is_empty to is_null
+        if ($this->isNull($title)) {
             return false;
         }
 
@@ -167,5 +169,16 @@ class DefaultValidator extends \Magento\Framework\Validator\AbstractValidator
     protected function isNegative($value)
     {
         return intval($value) < 0;
+    }
+
+    /**
+     * check whether title is null
+     *
+     * @param $title
+     * @return bool
+     */
+    protected function isNull($title)
+    {
+        return is_null($title);
     }
 }

--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Option/Value.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Option/Value.php
@@ -256,7 +256,8 @@ class Value extends AbstractDb
                 $object->unsetData('title');
             }
 
-            if ($object->getTitle()) {
+            /*** Checking whether title is not null ***/
+            if ($object->getTitle()!= null) {
                 if ($existInCurrentStore) {
                     if ($storeId == $object->getStoreId()) {
                         $where = [

--- a/app/code/Magento/Sales/Model/Order/Pdf/Items/Invoice/DefaultInvoice.php
+++ b/app/code/Magento/Sales/Model/Order/Pdf/Items/Invoice/DefaultInvoice.php
@@ -127,7 +127,8 @@ class DefaultInvoice extends \Magento\Sales\Model\Order\Pdf\Items\AbstractItems
                     'feed' => 35,
                 ];
 
-                if ($option['value']) {
+                // Checking if option value is null not as empty
+                if ($option['value']!= null) {
                     if (isset($option['print_value'])) {
                         $printValue = $option['print_value'];
                     } else {

--- a/app/code/Magento/Sales/Model/Order/Pdf/Items/Invoice/DefaultInvoice.php
+++ b/app/code/Magento/Sales/Model/Order/Pdf/Items/Invoice/DefaultInvoice.php
@@ -127,7 +127,7 @@ class DefaultInvoice extends \Magento\Sales\Model\Order\Pdf\Items\AbstractItems
                     'feed' => 35,
                 ];
 
-                // Checking if option value is null not as empty
+                // Checking whether option value is not null
                 if ($option['value']!= null) {
                     if (isset($option['print_value'])) {
                         $printValue = $option['print_value'];

--- a/app/code/Magento/Sales/Model/Order/Pdf/Items/Shipment/DefaultShipment.php
+++ b/app/code/Magento/Sales/Model/Order/Pdf/Items/Shipment/DefaultShipment.php
@@ -89,7 +89,6 @@ class DefaultShipment extends \Magento\Sales\Model\Order\Pdf\Items\AbstractItems
                 ];
 
                 // draw options value
-                // Checking if option value is null not as empty
                 if ($option['value']!= null) {
                     $printValue = isset(
                         $option['print_value']

--- a/app/code/Magento/Sales/Model/Order/Pdf/Items/Shipment/DefaultShipment.php
+++ b/app/code/Magento/Sales/Model/Order/Pdf/Items/Shipment/DefaultShipment.php
@@ -89,7 +89,8 @@ class DefaultShipment extends \Magento\Sales\Model\Order\Pdf\Items\AbstractItems
                 ];
 
                 // draw options value
-                if ($option['value']) {
+                // Checking if option value is null not as empty
+                if ($option['value']!= null) {
                     $printValue = isset(
                         $option['print_value']
                     ) ? $option['print_value'] : $this->filterManager->stripTags(


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15357
Resolved product custom option's title save issue when the title is set to zero.

Description:

Navigate Admin => Catalog => Products => Create New / Edit Product.

1. Go to customizable options tab and add any custom options with drop down option type.
2. Set zero(0) in the title field and click save the product.
3. Product will save successfully and store zero value as a title of the drop down option.


### Fixed Issues (if relevant)

1. magento/magento2#6305: Can't save Customizable options 
